### PR TITLE
Use smaller header image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHubGSD](https://github.com/user-attachments/assets/61eb0a79-1e91-4ae9-859f-0c4a2e368b37)
+![GitHubGSD](https://github.blog/wp-content/uploads/2024/09/1200x630-GHNonprofits_BlogB.png?w=1600)
 
 ---
 ## GitHub's Green Software Directory is a simple and easy-to-use resource that all developers can use to adopt green software tools. This list aims to help any developer find green software projects available on GitHub. 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file.

The change updates the image URL in the header for the GitHub Green Software Directory, to use the one on the Github blog that is much smaller. 

As a result, it loads much faster too. I'm guessing the smaller image is cached on the blog once created, so it I don't think this change would add much load to the server serving the image file.

Otherwise it might make sense to have this in the repo itself - this seemed a pretty quick change though.